### PR TITLE
Add JSON schemas for email MCP tools

### DIFF
--- a/individual_schema/email_add_category.schema.json
+++ b/individual_schema/email_add_category.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "email_add_category",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "email_id": {
+      "type": "string",
+      "description": "Identifier of the email to categorize."
+    },
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID performing the update."
+    },
+    "categories": {
+      "description": "Category name or list of category names; all entries must be non-empty strings.",
+      "anyOf": [
+        {"type": "string", "minLength": 1},
+        {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "minItems": 1
+        }
+      ]
+    }
+  },
+  "required": ["email_id", "account_id", "categories"]
+}

--- a/individual_schema/email_archive.schema.json
+++ b/individual_schema/email_archive.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "email_archive",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "email_id": {
+      "type": "string",
+      "description": "Identifier of the email to archive."
+    },
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID performing the archive action."
+    }
+  },
+  "required": ["email_id", "account_id"]
+}

--- a/individual_schema/email_create_draft.schema.json
+++ b/individual_schema/email_create_draft.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "email_create_draft",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID used to create the draft."
+    },
+    "to": {
+      "description": "Recipient email address or list of addresses.",
+      "anyOf": [
+        {"type": "string", "format": "email"},
+        {
+          "type": "array",
+          "items": {"type": "string", "format": "email"},
+          "minItems": 1
+        }
+      ]
+    },
+    "subject": {
+      "type": "string",
+      "description": "Email subject line."
+    },
+    "body": {
+      "type": "string",
+      "description": "Plain-text body content for the draft."
+    },
+    "cc": {
+      "description": "Optional CC recipient(s).",
+      "anyOf": [
+        {"type": "string", "format": "email"},
+        {
+          "type": "array",
+          "items": {"type": "string", "format": "email"},
+          "minItems": 1
+        }
+      ]
+    },
+    "attachments": {
+      "description": "Optional local file path or list of file paths to attach.",
+      "anyOf": [
+        {"type": "string"},
+        {
+          "type": "array",
+          "items": {"type": "string"},
+          "minItems": 1
+        }
+      ]
+    }
+  },
+  "required": ["account_id", "to", "subject", "body"]
+}

--- a/individual_schema/email_delete.schema.json
+++ b/individual_schema/email_delete.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "email_delete",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "email_id": {
+      "type": "string",
+      "description": "Identifier of the email to delete permanently."
+    },
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID owning the message."
+    },
+    "confirm": {
+      "type": "boolean",
+      "const": true,
+      "description": "Must be true to authorize permanent deletion."
+    }
+  },
+  "required": ["email_id", "account_id", "confirm"]
+}

--- a/individual_schema/email_flag.schema.json
+++ b/individual_schema/email_flag.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "email_flag",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "email_id": {
+      "type": "string",
+      "description": "Identifier of the email to flag or unflag."
+    },
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID performing the flag update."
+    },
+    "flag_status": {
+      "type": "string",
+      "enum": ["notFlagged", "flagged", "complete"],
+      "default": "flagged",
+      "description": "Flag state to apply (default flagged)."
+    }
+  },
+  "required": ["email_id", "account_id"]
+}

--- a/individual_schema/email_forward.schema.json
+++ b/individual_schema/email_forward.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "email_forward",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID performing the forward."
+    },
+    "email_id": {
+      "type": "string",
+      "description": "Identifier of the email to forward."
+    },
+    "to": {
+      "description": "Recipient email address or list of addresses (max 500 unique across To/CC).",
+      "anyOf": [
+        {"type": "string", "format": "email"},
+        {
+          "type": "array",
+          "items": {"type": "string", "format": "email"},
+          "minItems": 1,
+          "maxItems": 500
+        }
+      ]
+    },
+    "cc": {
+      "description": "Optional CC recipient(s) counted toward the 500 unique-recipient limit.",
+      "anyOf": [
+        {"type": "string", "format": "email"},
+        {
+          "type": "array",
+          "items": {"type": "string", "format": "email"},
+          "minItems": 1,
+          "maxItems": 500
+        }
+      ]
+    },
+    "body": {
+      "type": "string",
+      "description": "Optional plain-text comment to include with the forward (trimmed)."
+    },
+    "confirm": {
+      "type": "boolean",
+      "const": true,
+      "description": "Must be true to authorize forwarding the email."
+    }
+  },
+  "required": ["account_id", "email_id", "to", "confirm"]
+}

--- a/individual_schema/email_get.schema.json
+++ b/individual_schema/email_get.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "email_get",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "email_id": {
+      "type": "string",
+      "description": "Identifier of the target email message."
+    },
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID owning the email."
+    },
+    "include_body": {
+      "type": "boolean",
+      "default": true,
+      "description": "Include body content in the response when true."
+    },
+    "body_max_length": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 500000,
+      "default": 50000,
+      "description": "Maximum number of body characters to return before truncation."
+    },
+    "include_attachments": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether to expand attachment metadata."
+    },
+    "use_cache": {
+      "type": "boolean",
+      "default": true,
+      "description": "Allow cached data to satisfy the request when available."
+    },
+    "force_refresh": {
+      "type": "boolean",
+      "default": false,
+      "description": "Bypass cache and fetch from Graph even if cached data exists."
+    }
+  },
+  "required": ["email_id", "account_id"]
+}

--- a/individual_schema/email_get_attachment.schema.json
+++ b/individual_schema/email_get_attachment.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "email_get_attachment",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "email_id": {
+      "type": "string",
+      "description": "Microsoft Graph message identifier containing the attachment."
+    },
+    "attachment_id": {
+      "type": "string",
+      "description": "Identifier of the attachment within the message."
+    },
+    "save_path": {
+      "type": "string",
+      "description": "Destination file path for the downloaded attachment; validated to avoid unsafe or overwriting writes."
+    },
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID used for the download."
+    }
+  },
+  "required": ["email_id", "attachment_id", "save_path", "account_id"]
+}

--- a/individual_schema/email_list.schema.json
+++ b/individual_schema/email_list.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "email_list",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID used for the mailbox query."
+    },
+    "folder": {
+      "type": "string",
+      "description": "Well-known mail folder name; defaults to inbox when omitted.",
+      "enum": ["inbox", "sent", "drafts", "deleted", "junk", "archive"]
+    },
+    "folder_id": {
+      "type": "string",
+      "description": "Explicit folder identifier; takes precedence over folder name when provided."
+    },
+    "limit": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 200,
+      "default": 10,
+      "description": "Maximum number of messages to return (1-200)."
+    },
+    "include_body": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether to include message body content in results."
+    },
+    "use_cache": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether cached results may be used if available."
+    },
+    "force_refresh": {
+      "type": "boolean",
+      "default": false,
+      "description": "Bypass cache and always fetch fresh results when true."
+    }
+  },
+  "required": ["account_id"]
+}

--- a/individual_schema/email_mark_read.schema.json
+++ b/individual_schema/email_mark_read.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "email_mark_read",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "email_id": {
+      "type": "string",
+      "description": "Identifier of the email to mark read or unread."
+    },
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID performing the update."
+    },
+    "is_read": {
+      "type": "boolean",
+      "default": true,
+      "description": "True to mark as read, false to mark as unread."
+    }
+  },
+  "required": ["email_id", "account_id"]
+}

--- a/individual_schema/email_move.schema.json
+++ b/individual_schema/email_move.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "email_move",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "email_id": {
+      "type": "string",
+      "description": "Identifier of the email to move."
+    },
+    "destination_folder": {
+      "type": "string",
+      "enum": ["inbox", "sent", "drafts", "deleted", "junk", "archive"],
+      "description": "Well-known destination folder name."
+    },
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID performing the move."
+    }
+  },
+  "required": ["email_id", "destination_folder", "account_id"]
+}

--- a/individual_schema/email_reply.schema.json
+++ b/individual_schema/email_reply.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "email_reply",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID sending the reply."
+    },
+    "email_id": {
+      "type": "string",
+      "description": "Identifier of the email being replied to."
+    },
+    "body": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "\\S",
+      "description": "Plain-text reply body; must contain non-whitespace characters after trimming."
+    },
+    "confirm": {
+      "type": "boolean",
+      "const": true,
+      "description": "Must be true to authorize sending the reply."
+    }
+  },
+  "required": ["account_id", "email_id", "body", "confirm"]
+}

--- a/individual_schema/email_reply_all.schema.json
+++ b/individual_schema/email_reply_all.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "email_reply_all",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID sending the reply-all."
+    },
+    "email_id": {
+      "type": "string",
+      "description": "Identifier of the email being replied to."
+    },
+    "body": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "\\S",
+      "description": "Plain-text reply body; must contain non-whitespace characters after trimming."
+    },
+    "confirm": {
+      "type": "boolean",
+      "const": true,
+      "description": "Must be true to authorize replying to all recipients."
+    }
+  },
+  "required": ["account_id", "email_id", "body", "confirm"]
+}

--- a/individual_schema/email_send.schema.json
+++ b/individual_schema/email_send.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "email_send",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID used to send the message."
+    },
+    "to": {
+      "description": "Recipient email address or list of addresses (max 500 unique across To/CC).",
+      "anyOf": [
+        {"type": "string", "format": "email"},
+        {
+          "type": "array",
+          "items": {"type": "string", "format": "email"},
+          "minItems": 1,
+          "maxItems": 500
+        }
+      ]
+    },
+    "subject": {
+      "type": "string",
+      "description": "Email subject line."
+    },
+    "body": {
+      "type": "string",
+      "description": "Plain-text email body to send."
+    },
+    "cc": {
+      "description": "Optional CC recipient(s) counted toward the 500 unique-recipient limit.",
+      "anyOf": [
+        {"type": "string", "format": "email"},
+        {
+          "type": "array",
+          "items": {"type": "string", "format": "email"},
+          "minItems": 1,
+          "maxItems": 500
+        }
+      ]
+    },
+    "attachments": {
+      "description": "Optional local file path or list of file paths to attach.",
+      "anyOf": [
+        {"type": "string"},
+        {
+          "type": "array",
+          "items": {"type": "string"},
+          "minItems": 1
+        }
+      ]
+    },
+    "confirm": {
+      "type": "boolean",
+      "const": true,
+      "description": "Must be true to allow sending; protects against accidental dispatch."
+    }
+  },
+  "required": ["account_id", "to", "subject", "body", "confirm"]
+}

--- a/individual_schema/email_update.schema.json
+++ b/individual_schema/email_update.schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "email_update",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "email_id": {
+      "type": "string",
+      "description": "Identifier of the email to update."
+    },
+    "updates": {
+      "type": "object",
+      "description": "Dictionary of properties to modify (isRead, categories, importance, flag, inferenceClassification).",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "properties": {
+        "isRead": {
+          "type": "boolean",
+          "description": "Mark the message as read (true) or unread (false)."
+        },
+        "categories": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "minItems": 1,
+          "description": "List of category names to apply; each must be a non-empty string."
+        },
+        "importance": {
+          "type": "string",
+          "enum": ["low", "normal", "high"],
+          "description": "Importance level for the message."
+        },
+        "flag": {
+          "type": "object",
+          "description": "Message flag details; must include at least one flag field.",
+          "additionalProperties": false,
+          "minProperties": 1,
+          "properties": {
+            "flagStatus": {
+              "type": "string",
+              "enum": ["notFlagged", "flagged", "complete"],
+              "description": "Flag state."
+            },
+            "startDateTime": {
+              "type": "object",
+              "description": "Start timestamp with timezone for the flag.",
+              "additionalProperties": false,
+              "required": ["dateTime", "timeZone"],
+              "properties": {
+                "dateTime": {"type": "string", "format": "date-time"},
+                "timeZone": {"type": "string", "minLength": 1}
+              }
+            },
+            "dueDateTime": {
+              "type": "object",
+              "description": "Due timestamp with timezone; must be on or after startDateTime when both are provided.",
+              "additionalProperties": false,
+              "required": ["dateTime", "timeZone"],
+              "properties": {
+                "dateTime": {"type": "string", "format": "date-time"},
+                "timeZone": {"type": "string", "minLength": 1}
+              }
+            },
+            "completedDateTime": {
+              "type": "object",
+              "description": "Completion timestamp with timezone for the flag.",
+              "additionalProperties": false,
+              "required": ["dateTime", "timeZone"],
+              "properties": {
+                "dateTime": {"type": "string", "format": "date-time"},
+                "timeZone": {"type": "string", "minLength": 1}
+              }
+            }
+          }
+        },
+        "inferenceClassification": {
+          "type": "string",
+          "enum": ["focused", "other"],
+          "description": "Focused Inbox classification."
+        }
+      }
+    },
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID executing the update."
+    }
+  },
+  "required": ["email_id", "updates", "account_id"]
+}


### PR DESCRIPTION
## Summary
- add an individual_schema directory with JSON Schema files for every email MCP tool
- encode parameter types, defaults, enumerations, and confirmation requirements based on tool implementations
- document recipient limits, folder options, and validation boundaries in the schemas

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69382802a164832bbd3fd0e9dd2ef29a)