### PR TITLE
Add utility tool JSON schemas

### DIFF
--- a/individual_schema/account_authenticate.schema.json
+++ b/individual_schema/account_authenticate.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "account_authenticate",
+  "type": "object",
+  "additionalProperties": false,
+  "description": "Initiate device-flow authentication for adding a new Microsoft account.",
+  "properties": {}
+}

--- a/individual_schema/account_complete_auth.schema.json
+++ b/individual_schema/account_complete_auth.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "account_complete_auth",
+  "type": "object",
+  "additionalProperties": false,
+  "description": "Complete device-flow authentication using the cached flow payload returned by account_authenticate.",
+  "properties": {
+    "flow_cache": {
+      "type": "string",
+      "description": "Stringified device-flow payload returned as _flow_cache from account_authenticate.",
+      "minLength": 1
+    }
+  },
+  "required": ["flow_cache"]
+}

--- a/individual_schema/account_list.schema.json
+++ b/individual_schema/account_list.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "account_list",
+  "type": "object",
+  "additionalProperties": false,
+  "description": "List all signed-in Microsoft accounts (read-only).",
+  "properties": {}
+}

--- a/individual_schema/search_unified.schema.json
+++ b/individual_schema/search_unified.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "search_unified",
+  "type": "object",
+  "additionalProperties": false,
+  "description": "Search emails, events, and files simultaneously with optional cache controls.",
+  "properties": {
+    "query": {
+      "type": "string",
+      "description": "Search phrase trimmed of surrounding whitespace.",
+      "minLength": 1,
+      "maxLength": 512
+    },
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account identifier used to scope the search."
+    },
+    "entity_types": {
+      "description": "Optional subset of entity types to search; defaults to all when omitted.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": ["message", "event", "driveItem"],
+          "description": "Single entity type."
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["message", "event", "driveItem"]
+          },
+          "description": "Array of entity types; order is preserved but internally normalized."
+        }
+      ]
+    },
+    "limit": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 500,
+      "default": 50,
+      "description": "Maximum number of results returned per entity type."
+    },
+    "use_cache": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether cached results may be used if available."
+    },
+    "force_refresh": {
+      "type": "boolean",
+      "default": false,
+      "description": "Bypass cache and force a fresh search when true."
+    }
+  },
+  "required": ["query", "account_id"]
+}


### PR DESCRIPTION
## Summary
- add JSON Schemas for account utility tooling inputs
- add unified search schema capturing query and cache parameters

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693829f5d68c832b872a2d052e2faef6)