### PR TITLE
Add calendar tool JSON schemas

### DIFF
--- a/individual_schema/calendar_check_availability.schema.json
+++ b/individual_schema/calendar_check_availability.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "calendar_check_availability",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID used for the availability lookup."
+    },
+    "start": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Start of the availability window in ISO-8601 format."
+    },
+    "end": {
+      "type": "string",
+      "format": "date-time",
+      "description": "End of the availability window in ISO-8601 format."
+    },
+    "attendees": {
+      "oneOf": [
+        {"type": "string"},
+        {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "List of attendee email addresses to include."
+        }
+      ],
+      "description": "Optional attendee email or list; limited to 500 unique addresses."
+    }
+  },
+  "required": ["account_id", "start", "end"]
+}

--- a/individual_schema/calendar_create_calendar.schema.json
+++ b/individual_schema/calendar_create_calendar.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "calendar_create_calendar",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID where the calendar will be created."
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Name for the new calendar; must be non-empty."
+    }
+  },
+  "required": ["account_id", "name"]
+}

--- a/individual_schema/calendar_create_event.schema.json
+++ b/individual_schema/calendar_create_event.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "calendar_create_event",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID where the event will be created."
+    },
+    "subject": {
+      "type": "string",
+      "description": "Event subject or title."
+    },
+    "start": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Start time in ISO-8601 format."
+    },
+    "end": {
+      "type": "string",
+      "format": "date-time",
+      "description": "End time in ISO-8601 format; must be after start."
+    },
+    "location": {
+      "type": "string",
+      "description": "Optional location display name for the event."
+    },
+    "body": {
+      "type": "string",
+      "description": "Optional plain text body or description."
+    },
+    "attendees": {
+      "oneOf": [
+        {"type": "string"},
+        {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "List of attendee email addresses (duplicates removed automatically)."
+        }
+      ],
+      "description": "Attendee email address or array of addresses; limited to 500 unique entries."
+    },
+    "timezone": {
+      "type": "string",
+      "default": "UTC",
+      "description": "IANA timezone identifier applied to start/end values (default UTC)."
+    }
+  },
+  "required": ["account_id", "subject", "start", "end"]
+}

--- a/individual_schema/calendar_delete_calendar.schema.json
+++ b/individual_schema/calendar_delete_calendar.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "calendar_delete_calendar",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID for the calendar owner."
+    },
+    "calendar_id": {
+      "type": "string",
+      "description": "Identifier of the calendar to delete."
+    },
+    "confirm": {
+      "const": true,
+      "type": "boolean",
+      "default": true,
+      "description": "Must be true to permit permanent calendar deletion."
+    }
+  },
+  "required": ["account_id", "calendar_id", "confirm"]
+}

--- a/individual_schema/calendar_delete_event.schema.json
+++ b/individual_schema/calendar_delete_event.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "calendar_delete_event",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID for the calendar."
+    },
+    "event_id": {
+      "type": "string",
+      "description": "Identifier of the event to delete."
+    },
+    "send_cancellation": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether to send cancellation notices to attendees."
+    },
+    "confirm": {
+      "const": true,
+      "type": "boolean",
+      "default": true,
+      "description": "Must be true to allow deletion (safety confirmation)."
+    }
+  },
+  "required": ["account_id", "event_id", "confirm"]
+}

--- a/individual_schema/calendar_forward_event.schema.json
+++ b/individual_schema/calendar_forward_event.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "calendar_forward_event",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID for the calendar."
+    },
+    "event_id": {
+      "type": "string",
+      "description": "Identifier of the event to forward."
+    },
+    "to": {
+      "oneOf": [
+        {"type": "string"},
+        {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "Primary recipients for the forwarded invitation."
+        }
+      ],
+      "description": "Recipient email or list; combined with CC must not exceed 500 unique addresses."
+    },
+    "cc": {
+      "oneOf": [
+        {"type": "string"},
+        {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "Optional CC recipients."
+        }
+      ],
+      "description": "Optional CC email or list; combined recipients limited to 500 unique addresses."
+    },
+    "message": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Optional plain text comment to include with the forward."
+    },
+    "confirm": {
+      "const": true,
+      "type": "boolean",
+      "default": true,
+      "description": "Must be true to allow forwarding (safety confirmation)."
+    }
+  },
+  "required": ["account_id", "event_id", "to", "confirm"]
+}

--- a/individual_schema/calendar_get_event.schema.json
+++ b/individual_schema/calendar_get_event.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "calendar_get_event",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "event_id": {
+      "type": "string",
+      "description": "Identifier of the event to retrieve."
+    },
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID associated with the calendar."
+    },
+    "use_cache": {
+      "type": "boolean",
+      "default": true,
+      "description": "Allow returning cached event details when available."
+    },
+    "force_refresh": {
+      "type": "boolean",
+      "default": false,
+      "description": "Bypass cache and fetch fresh data when true."
+    }
+  },
+  "required": ["event_id", "account_id"]
+}

--- a/individual_schema/calendar_get_free_busy.schema.json
+++ b/individual_schema/calendar_get_free_busy.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "calendar_get_free_busy",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID used for the free/busy request."
+    },
+    "attendees": {
+      "oneOf": [
+        {"type": "string"},
+        {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "List of attendee email addresses to evaluate."
+        }
+      ],
+      "description": "Required attendee email or list; limited to 500 unique addresses."
+    },
+    "start": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Start of the free/busy window in ISO-8601 format."
+    },
+    "end": {
+      "type": "string",
+      "format": "date-time",
+      "description": "End of the free/busy window in ISO-8601 format."
+    },
+    "time_interval": {
+      "type": "integer",
+      "minimum": 5,
+      "maximum": 1440,
+      "default": 30,
+      "description": "Availability view interval in minutes (5-1440)."
+    }
+  },
+  "required": ["account_id", "attendees", "start", "end"]
+}

--- a/individual_schema/calendar_list_calendars.schema.json
+++ b/individual_schema/calendar_list_calendars.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "calendar_list_calendars",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID used to fetch calendars."
+    },
+    "use_cache": {
+      "type": "boolean",
+      "default": true,
+      "description": "Allow returning cached calendar listings when available."
+    },
+    "force_refresh": {
+      "type": "boolean",
+      "default": false,
+      "description": "Bypass cache and fetch fresh results when true."
+    }
+  },
+  "required": ["account_id"]
+}

--- a/individual_schema/calendar_list_events.schema.json
+++ b/individual_schema/calendar_list_events.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "calendar_list_events",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID used for the calendar query."
+    },
+    "days_ahead": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 365,
+      "default": 7,
+      "description": "Number of days ahead to fetch events (1-365)."
+    },
+    "include_details": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether to include full event details such as attendees and body content."
+    },
+    "limit": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 200,
+      "default": 50,
+      "description": "Maximum number of events to return (1-200)."
+    },
+    "use_cache": {
+      "type": "boolean",
+      "default": true,
+      "description": "Allow returning cached results when available."
+    },
+    "force_refresh": {
+      "type": "boolean",
+      "default": false,
+      "description": "Bypass cache and fetch fresh results when true."
+    }
+  },
+  "required": ["account_id"]
+}

--- a/individual_schema/calendar_propose_new_time.schema.json
+++ b/individual_schema/calendar_propose_new_time.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "calendar_propose_new_time",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID for the attendee proposing a new time."
+    },
+    "event_id": {
+      "type": "string",
+      "description": "Identifier of the meeting event."
+    },
+    "proposed_start": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Proposed start time in ISO-8601 format."
+    },
+    "proposed_end": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Proposed end time in ISO-8601 format; must occur after the start."
+    },
+    "message": {
+      "type": "string",
+      "description": "Optional message to include with the proposal."
+    }
+  },
+  "required": ["account_id", "event_id", "proposed_start", "proposed_end"]
+}

--- a/individual_schema/calendar_respond_event.schema.json
+++ b/individual_schema/calendar_respond_event.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "calendar_respond_event",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID for the calendar."
+    },
+    "event_id": {
+      "type": "string",
+      "description": "Identifier of the event invitation to respond to."
+    },
+    "response": {
+      "type": "string",
+      "enum": ["accept", "decline", "tentativelyAccept", "tentative"],
+      "default": "accept",
+      "description": "Response action to send to the organizer."
+    },
+    "message": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Optional message for the organizer; must be non-empty when provided."
+    }
+  },
+  "required": ["account_id", "event_id"]
+}

--- a/individual_schema/calendar_update_event.schema.json
+++ b/individual_schema/calendar_update_event.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "calendar_update_event",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "event_id": {
+      "type": "string",
+      "description": "Identifier of the event to update."
+    },
+    "updates": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "properties": {
+        "subject": {
+          "type": "string",
+          "description": "New subject for the event."
+        },
+        "start": {
+          "type": "string",
+          "format": "date-time",
+          "description": "New start time in ISO-8601 format."
+        },
+        "end": {
+          "type": "string",
+          "format": "date-time",
+          "description": "New end time in ISO-8601 format."
+        },
+        "timezone": {
+          "type": "string",
+          "description": "Timezone to apply when start or end is provided."
+        },
+        "location": {
+          "type": "string",
+          "description": "Updated location display name."
+        },
+        "body": {
+          "type": "string",
+          "description": "Updated plain text body content."
+        },
+        "attendees": {
+          "oneOf": [
+            {"type": "string"},
+            {
+              "type": "array",
+              "items": {"type": "string"},
+              "description": "Updated attendee list; empty array clears attendees."
+            }
+          ],
+          "description": "New attendee email address or list; limited to 500 unique entries."
+        }
+      },
+      "description": "Dictionary of fields to update. Allowed keys: subject, start, end, timezone, location, body, attendees."
+    },
+    "account_id": {
+      "type": "string",
+      "description": "Microsoft account ID associated with the calendar."
+    }
+  },
+  "required": ["event_id", "updates", "account_id"]
+}


### PR DESCRIPTION
## Summary
- add JSON Schema definitions for calendar event retrieval and listing tools
- cover event creation, updates, responses, forwarding, and availability workflows
- include calendar management schemas with required safety confirmations

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693829acd7c8832ba5b007856f22aafd)