### PR TITLE
Add JSON schemas for file tools

### DIFF
--- a/individual_schema/file_create.schema.json
+++ b/individual_schema/file_create.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "file_create",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "onedrive_path": {
+      "type": "string",
+      "pattern": "^/.*$",
+      "description": "Destination OneDrive path beginning with '/'; '..' segments and reserved characters are rejected."
+    },
+    "local_file_path": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Absolute path to an existing local file to upload; must reside within allowed directories."
+    },
+    "account_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Microsoft account ID used for the upload."
+    }
+  },
+  "required": ["onedrive_path", "local_file_path", "account_id"]
+}

--- a/individual_schema/file_delete.schema.json
+++ b/individual_schema/file_delete.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "file_delete",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "file_id": {
+      "type": "string",
+      "pattern": "[A-Za-z0-9\-._!+=/$]{1,512}",
+      "description": "Microsoft Graph driveItem identifier for the file or folder to delete permanently."
+    },
+    "account_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Microsoft account ID associated with the item."
+    },
+    "confirm": {
+      "type": "boolean",
+      "const": true,
+      "description": "Must be true to authorize irreversible deletion."
+    }
+  },
+  "required": ["file_id", "account_id", "confirm"]
+}

--- a/individual_schema/file_get.schema.json
+++ b/individual_schema/file_get.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "file_get",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "file_id": {
+      "type": "string",
+      "pattern": "[A-Za-z0-9\-._!+=/$]{1,512}",
+      "description": "Microsoft Graph driveItem identifier for the file to download."
+    },
+    "account_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Microsoft account ID associated with the file."
+    },
+    "download_path": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Absolute local path to save the downloaded file; must reside within allowed directories and cannot overwrite existing files."
+    }
+  },
+  "required": ["file_id", "account_id", "download_path"]
+}

--- a/individual_schema/file_list.schema.json
+++ b/individual_schema/file_list.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "file_list",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "account_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Microsoft account identifier owning the OneDrive content."
+    },
+    "path": {
+      "type": "string",
+      "default": "/",
+      "pattern": "^/.*$",
+      "description": "OneDrive path to list (must start with '/'; parent directory segments and reserved characters are rejected)."
+    },
+    "folder_id": {
+      "type": "string",
+      "pattern": "[A-Za-z0-9\-._!+=/$]{1,512}",
+      "description": "Optional Microsoft Graph driveItem identifier; overrides path when provided."
+    },
+    "limit": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 500,
+      "default": 50,
+      "description": "Maximum number of items to return (1-500)."
+    },
+    "type_filter": {
+      "type": "string",
+      "enum": ["all", "files", "folders"],
+      "default": "all",
+      "description": "Filter results by item type."
+    },
+    "use_cache": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether cached results may be used if available."
+    },
+    "force_refresh": {
+      "type": "boolean",
+      "default": false,
+      "description": "Bypass cache and fetch fresh data when true."
+    }
+  },
+  "required": ["account_id"]
+}

--- a/individual_schema/file_update.schema.json
+++ b/individual_schema/file_update.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "file_update",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "file_id": {
+      "type": "string",
+      "pattern": "[A-Za-z0-9\-._!+=/$]{1,512}",
+      "description": "Microsoft Graph driveItem identifier for the file to replace."
+    },
+    "local_file_path": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Absolute path to an existing local file whose contents will replace the OneDrive item."
+    },
+    "account_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Microsoft account ID owning the target file."
+    }
+  },
+  "required": ["file_id", "local_file_path", "account_id"]
+}

--- a/individual_schema/search_files.schema.json
+++ b/individual_schema/search_files.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "search_files",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "query": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "description": "Search text used to find matching OneDrive items; leading and trailing whitespace is trimmed."
+    },
+    "account_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Microsoft account ID to scope the search."
+    },
+    "limit": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 500,
+      "default": 50,
+      "description": "Maximum number of search results to return (1-500)."
+    },
+    "use_cache": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether cached search results may be returned."
+    },
+    "force_refresh": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, bypass cache and query Microsoft Graph directly."
+    }
+  },
+  "required": ["query", "account_id"]
+}


### PR DESCRIPTION
## Summary
- add JSON Schema definitions for OneDrive file tools (list, get, create, update, delete)
- document search_files input validation in a dedicated schema file

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693829e4d87c832b8b58d570d2375f84)