### PR TITLE
Add JSON schemas for cache management tools

### DIFF
--- a/individual_schema/cache_get_stats.schema.json
+++ b/individual_schema/cache_get_stats.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "cache_get_stats",
+  "type": "object",
+  "description": "Retrieve aggregate cache statistics including hit/miss counts and size metrics.",
+  "additionalProperties": false,
+  "properties": {}
+}

--- a/individual_schema/cache_invalidate.schema.json
+++ b/individual_schema/cache_invalidate.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "cache_invalidate",
+  "type": "object",
+  "description": "Invalidate cache entries matching a wildcard pattern with optional account scoping.",
+  "additionalProperties": false,
+  "properties": {
+    "pattern": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Cache key pattern supporting '*' wildcards (e.g., 'email_list:*', 'folder_get_tree:user@example.com:*')."
+    },
+    "account_id": {
+      "type": "string",
+      "description": "Optional account identifier to scope invalidation; when provided, the pattern is updated to include this account if missing."
+    },
+    "reason": {
+      "type": "string",
+      "description": "Reason recorded for the invalidation audit log.",
+      "default": "manual_invalidation"
+    }
+  },
+  "required": ["pattern"]
+}

--- a/individual_schema/cache_task_enqueue.schema.json
+++ b/individual_schema/cache_task_enqueue.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "cache_task_enqueue",
+  "type": "object",
+  "description": "Enqueue a background cache task with operation parameters and priority.",
+  "additionalProperties": false,
+  "properties": {
+    "account_id": {
+      "type": "string",
+      "description": "Account identifier for which the background task should run."
+    },
+    "operation": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Operation name to execute (e.g., 'folder_get_tree', 'email_list')."
+    },
+    "parameters": {
+      "type": "object",
+      "description": "Operation-specific parameters serialized into the task payload.",
+      "default": {},
+      "additionalProperties": true
+    },
+    "priority": {
+      "type": "integer",
+      "description": "Task priority where 1 is highest urgency and 10 is lowest.",
+      "minimum": 1,
+      "maximum": 10,
+      "default": 5
+    }
+  },
+  "required": ["account_id", "operation"]
+}

--- a/individual_schema/cache_task_get_status.schema.json
+++ b/individual_schema/cache_task_get_status.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "cache_task_get_status",
+  "type": "object",
+  "description": "Fetch the current status and metadata for a background cache task.",
+  "additionalProperties": false,
+  "properties": {
+    "task_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique identifier returned when the cache task was enqueued."
+    }
+  },
+  "required": ["task_id"]
+}

--- a/individual_schema/cache_task_list.schema.json
+++ b/individual_schema/cache_task_list.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "cache_task_list",
+  "type": "object",
+  "description": "List background cache tasks with optional filtering and pagination controls.",
+  "additionalProperties": false,
+  "properties": {
+    "account_id": {
+      "type": "string",
+      "description": "Optional account identifier used to filter tasks belonging to a specific user."
+    },
+    "status": {
+      "type": "string",
+      "description": "Optional status filter limiting results to tasks in a particular lifecycle state.",
+      "enum": ["queued", "running", "completed", "failed"]
+    },
+    "limit": {
+      "type": "integer",
+      "description": "Maximum number of tasks to return, ordered by most recent creation time.",
+      "minimum": 1,
+      "default": 50
+    }
+  }
+}

--- a/individual_schema/cache_warming_status.schema.json
+++ b/individual_schema/cache_warming_status.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "cache_warming_status",
+  "type": "object",
+  "description": "Report whether background cache warming is active and summarize progress.",
+  "additionalProperties": false,
+  "properties": {}
+}


### PR DESCRIPTION
## Summary
- add JSON Schemas for cache management tool inputs covering statistics, invalidation, task queue operations, and warming status
- capture parameter constraints such as wildcard patterns, task identifiers, priority bounds, and status enums for validation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69382a04f580832ba4a79b33a28e0bb1)