### PR TITLE
Add unified schemas for consolidated toolset

### DIFF
--- a/unified_schema/README.md
+++ b/unified_schema/README.md
@@ -1,0 +1,79 @@
+# Unified Tool Schema Proposal
+
+This folder introduces a consolidated JSON Schema layer that wraps the existing
+operation-specific schemas into a smaller, predictable tool surface. Each
+unified schema uses a common envelope with two fields:
+
+- `resource`: discriminator that selects the target entity or operation flavor.
+- `parameters`: the exact payload validated by the current individual schema for
+  that operation.
+
+Using this pattern keeps the detailed validation logic from
+`individual_schema/` intact while exposing a compact tool catalogue for MCP
+clients.
+
+## Unified tool list
+
+| Unified tool | Resources (via `resource` discriminator) | Underlying individual schema(s) |
+| --- | --- | --- |
+| `list` | `emails`, `events`, `contacts`, `files` | `email_list`, `calendar_list_events`, `contact_list`, `file_list` |
+| `get` | `email`, `attachment`, `event`, `availability`, `contact`, `file` | `email_get`, `email_get_attachment`, `calendar_get_event`, `calendar_check_availability`, `contact_get`, `file_get` |
+| `create` | `email_draft`, `event`, `contact`, `file` | `email_create_draft`, `calendar_create_event`, `contact_create`, `file_create` |
+| `send` | `email` | `email_send` |
+| `reply` | `email`, `email_all`, `event` | `email_reply`, `email_reply_all`, `calendar_respond_event` |
+| `update` | `email`, `event`, `contact`, `file` | `email_update`, `calendar_update_event`, `contact_update`, `file_update` |
+| `move` | `email` | `email_move` (file/folder moves can be added when schemas exist) |
+| `delete` | `email`, `event`, `contact`, `file`, `calendar` | `email_delete`, `calendar_delete_event`, `contact_delete`, `file_delete`, `calendar_delete_calendar` |
+| `search` | `emails`, `events`, `files`, `unified` | `search_unified` (with constrained `entity_types` for emails/events) and `search_files` |
+| `auth` | `list`, `authenticate`, `complete` | `account_list`, `account_authenticate`, `account_complete_auth` |
+| `cache` | `get_stats`, `invalidate`, `task_enqueue`, `task_status`, `task_list`, `warming_status` | `cache_get_stats`, `cache_invalidate`, `cache_task_enqueue`, `cache_task_get_status`, `cache_task_list`, `cache_warming_status` |
+
+## Design notes
+
+- **Compatibility-first**: the unified schemas wrap (not replace) the existing
+  per-tool schemas through `$ref` or `allOf`, so any updates to the underlying
+  validators automatically flow into the unified surface.
+- **Discriminated unions**: every unified schema declares a `discriminator`
+  pointing at `resource`, making it clear which parameter schema applies for a
+  given call.
+- **Safety preservation**: destructive and send operations still depend on the
+  underlying schema requirements (for example `confirm: true` on send/delete),
+  so the unified layer inherits those safeguards.
+- **Extensibility**: placeholders like `move` can accept additional resources
+  (e.g., OneDrive moves) simply by adding a new branch that references the
+  future schema without changing the envelope shape.
+- **Consistency**: cache/auth/search entries keep their specialized controls
+  (task status, entity type selection, etc.) but remain discoverable as one
+  verb with resource variants.
+
+## Usage example
+
+To list files:
+
+```json
+{
+  "resource": "files",
+  "parameters": {
+    "account_id": "...",
+    "path": "/",
+    "limit": 25
+  }
+}
+```
+
+To search only emails using the unified search schema:
+
+```json
+{
+  "resource": "emails",
+  "parameters": {
+    "query": "quarterly report",
+    "account_id": "...",
+    "entity_types": "message"
+  }
+}
+```
+
+Existing tooling can keep emitting the individual payloads; the unified layer
+just standardizes the wrapper and routing logic needed to register a smaller
+set of MCP tools.

--- a/unified_schema/auth.schema.json
+++ b/unified_schema/auth.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "auth",
+  "description": "Unified authentication and account management entry point.",
+  "oneOf": [
+    {
+      "title": "list accounts",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "list"},
+        "parameters": {"$ref": "../individual_schema/account_list.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "authenticate account",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "authenticate"},
+        "parameters": {"$ref": "../individual_schema/account_authenticate.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "complete authentication",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "complete"},
+        "parameters": {"$ref": "../individual_schema/account_complete_auth.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    }
+  ],
+  "discriminator": {
+    "propertyName": "resource"
+  }
+}

--- a/unified_schema/cache.schema.json
+++ b/unified_schema/cache.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "cache",
+  "description": "Unified cache management entry point.",
+  "oneOf": [
+    {
+      "title": "cache stats",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "get_stats"},
+        "parameters": {"$ref": "../individual_schema/cache_get_stats.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "invalidate cache",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "invalidate"},
+        "parameters": {"$ref": "../individual_schema/cache_invalidate.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "enqueue cache task",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "task_enqueue"},
+        "parameters": {"$ref": "../individual_schema/cache_task_enqueue.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "cache task status",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "task_status"},
+        "parameters": {"$ref": "../individual_schema/cache_task_get_status.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "list cache tasks",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "task_list"},
+        "parameters": {"$ref": "../individual_schema/cache_task_list.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "cache warming status",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "warming_status"},
+        "parameters": {"$ref": "../individual_schema/cache_warming_status.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    }
+  ],
+  "discriminator": {
+    "propertyName": "resource"
+  }
+}

--- a/unified_schema/create.schema.json
+++ b/unified_schema/create.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "create",
+  "description": "Unified creation for drafts, events, contacts, and OneDrive files.",
+  "oneOf": [
+    {
+      "title": "create email draft",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "email_draft"},
+        "parameters": {"$ref": "../individual_schema/email_create_draft.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "create event",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "event"},
+        "parameters": {"$ref": "../individual_schema/calendar_create_event.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "create contact",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "contact"},
+        "parameters": {"$ref": "../individual_schema/contact_create.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "create file",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "file"},
+        "parameters": {"$ref": "../individual_schema/file_create.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    }
+  ],
+  "discriminator": {
+    "propertyName": "resource"
+  }
+}

--- a/unified_schema/delete.schema.json
+++ b/unified_schema/delete.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "delete",
+  "description": "Unified delete entry point for destructive operations.",
+  "oneOf": [
+    {
+      "title": "delete email",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "email"},
+        "parameters": {"$ref": "../individual_schema/email_delete.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "delete event",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "event"},
+        "parameters": {"$ref": "../individual_schema/calendar_delete_event.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "delete contact",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "contact"},
+        "parameters": {"$ref": "../individual_schema/contact_delete.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "delete file",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "file"},
+        "parameters": {"$ref": "../individual_schema/file_delete.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "delete calendar",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "calendar"},
+        "parameters": {"$ref": "../individual_schema/calendar_delete_calendar.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    }
+  ],
+  "discriminator": {
+    "propertyName": "resource"
+  }
+}

--- a/unified_schema/get.schema.json
+++ b/unified_schema/get.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "get",
+  "description": "Unified retrieval for individual resources and availability windows.",
+  "oneOf": [
+    {
+      "title": "get email",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "email"},
+        "parameters": {"$ref": "../individual_schema/email_get.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "get email attachment",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "attachment"},
+        "parameters": {"$ref": "../individual_schema/email_get_attachment.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "get event",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "event"},
+        "parameters": {"$ref": "../individual_schema/calendar_get_event.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "get availability",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "availability"},
+        "parameters": {"$ref": "../individual_schema/calendar_check_availability.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "get contact",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "contact"},
+        "parameters": {"$ref": "../individual_schema/contact_get.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "get file",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "file"},
+        "parameters": {"$ref": "../individual_schema/file_get.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    }
+  ],
+  "discriminator": {
+    "propertyName": "resource"
+  }
+}

--- a/unified_schema/list.schema.json
+++ b/unified_schema/list.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "list",
+  "description": "Unified list entry point for emails, events, contacts, or files.",
+  "oneOf": [
+    {
+      "title": "list emails",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {
+          "const": "emails",
+          "description": "List messages from a mailbox folder."
+        },
+        "parameters": {
+          "$ref": "../individual_schema/email_list.schema.json"
+        }
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "list events",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {
+          "const": "events",
+          "description": "List calendar events within a time window."
+        },
+        "parameters": {
+          "$ref": "../individual_schema/calendar_list_events.schema.json"
+        }
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "list contacts",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {
+          "const": "contacts",
+          "description": "List contacts for an account."
+        },
+        "parameters": {
+          "$ref": "../individual_schema/contact_list.schema.json"
+        }
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "list files",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {
+          "const": "files",
+          "description": "List OneDrive items by path or folder id."
+        },
+        "parameters": {
+          "$ref": "../individual_schema/file_list.schema.json"
+        }
+      },
+      "required": ["resource", "parameters"]
+    }
+  ],
+  "discriminator": {
+    "propertyName": "resource"
+  }
+}

--- a/unified_schema/move.schema.json
+++ b/unified_schema/move.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "move",
+  "description": "Unified move operation (currently mail messages).",
+  "oneOf": [
+    {
+      "title": "move email",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "email"},
+        "parameters": {"$ref": "../individual_schema/email_move.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    }
+  ],
+  "discriminator": {
+    "propertyName": "resource"
+  }
+}

--- a/unified_schema/reply.schema.json
+++ b/unified_schema/reply.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "reply",
+  "description": "Unified reply entry point for emails and calendar invites.",
+  "oneOf": [
+    {
+      "title": "reply to email",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "email"},
+        "parameters": {"$ref": "../individual_schema/email_reply.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "reply all to email",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "email_all"},
+        "parameters": {"$ref": "../individual_schema/email_reply_all.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "respond to event",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "event"},
+        "parameters": {"$ref": "../individual_schema/calendar_respond_event.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    }
+  ],
+  "discriminator": {
+    "propertyName": "resource"
+  }
+}

--- a/unified_schema/search.schema.json
+++ b/unified_schema/search.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "search",
+  "description": "Unified search entry point.",
+  "oneOf": [
+    {
+      "title": "search emails",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "emails"},
+        "parameters": {
+          "allOf": [
+            {"$ref": "../individual_schema/search_unified.schema.json"},
+            {
+              "properties": {"entity_types": {"const": "message"}},
+              "required": ["entity_types"]
+            }
+          ]
+        }
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "search events",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "events"},
+        "parameters": {
+          "allOf": [
+            {"$ref": "../individual_schema/search_unified.schema.json"},
+            {
+              "properties": {"entity_types": {"const": "event"}},
+              "required": ["entity_types"]
+            }
+          ]
+        }
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "search files",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "files"},
+        "parameters": {"$ref": "../individual_schema/search_files.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "search multiple entity types",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "unified"},
+        "parameters": {"$ref": "../individual_schema/search_unified.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    }
+  ],
+  "discriminator": {
+    "propertyName": "resource"
+  }
+}

--- a/unified_schema/send.schema.json
+++ b/unified_schema/send.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "send",
+  "description": "Unified send entry point for outbound email.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "resource": {
+      "const": "email",
+      "description": "Send a new email or existing draft."
+    },
+    "parameters": {
+      "$ref": "../individual_schema/email_send.schema.json"
+    }
+  },
+  "required": ["resource", "parameters"]
+}

--- a/unified_schema/update.schema.json
+++ b/unified_schema/update.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "update",
+  "description": "Unified update entry point for mutable resources.",
+  "oneOf": [
+    {
+      "title": "update email",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "email"},
+        "parameters": {"$ref": "../individual_schema/email_update.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "update event",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "event"},
+        "parameters": {"$ref": "../individual_schema/calendar_update_event.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "update contact",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "contact"},
+        "parameters": {"$ref": "../individual_schema/contact_update.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    },
+    {
+      "title": "update file",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resource": {"const": "file"},
+        "parameters": {"$ref": "../individual_schema/file_update.schema.json"}
+      },
+      "required": ["resource", "parameters"]
+    }
+  ],
+  "discriminator": {
+    "propertyName": "resource"
+  }
+}


### PR DESCRIPTION
## Summary
- add unified JSON Schemas that wrap existing per-tool definitions under a resource discriminator
- document mapping between unified tools and underlying schemas to preserve compatibility
- include cache/auth/search coverage and placeholders for future move/file support

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69382dffcea4832bbfa395cab29bd2d3)