### PR TITLE
Add offline access scope to support silent token refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,7 @@ uvx ruff check --fix --unsafe-fixes .
 ## Azure App Requirements
 
 Required delegated permissions:
+- offline_access
 - Mail.ReadWrite
 - Calendars.ReadWrite
 - Files.ReadWrite

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ cache_invalidate("email_*", account_id="account-123")
 3. Supported account types: Personal + Work/School
 4. Authentication → Allow public client flows: Yes
 5. API permissions → Add these delegated permissions:
+   - offline_access
    - Mail.ReadWrite
    - Calendars.ReadWrite
    - Files.ReadWrite

--- a/src/m365_mcp/auth.py
+++ b/src/m365_mcp/auth.py
@@ -13,6 +13,7 @@ from typing import NamedTuple, Any
 CACHE_FILE = pl.Path.home() / ".m365_mcp_token_cache.json"
 METADATA_FILE = pl.Path.home() / ".m365_mcp_account_metadata.json"
 SCOPES = [
+    "offline_access",  # Required for refresh tokens and silent renewal
     "Calendars.Read",
     "Calendars.ReadBasic",
     "Calendars.ReadWrite",


### PR DESCRIPTION
## Summary
- request the offline_access scope so refresh tokens allow silent Graph reauthentication
- update authentication setup docs to mention the new required delegated permission

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69446df7cc00832b82ed39d4df26b54a)