### PR TITLE
Retry device flow against consumers for personal refresh tokens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,7 @@ uvx ruff check --fix --unsafe-fixes .
 ## Azure App Requirements
 
 Required delegated permissions:
+- offline_access
 - Mail.ReadWrite
 - Calendars.ReadWrite
 - Files.ReadWrite

--- a/README.md
+++ b/README.md
@@ -196,12 +196,13 @@ cache_invalidate("email_*", account_id="account-123")
 3. Supported account types: Personal + Work/School
 4. Authentication → Allow public client flows: Yes
 5. API permissions → Add these delegated permissions:
-   - Mail.ReadWrite
-   - Calendars.ReadWrite
-   - Files.ReadWrite
-   - Contacts.Read
-   - People.Read
-   - User.Read
+  - offline_access (required for refresh tokens; the CLI retries against the consumers authority if a personal account flags it as reserved)
+  - Mail.ReadWrite
+  - Calendars.ReadWrite
+  - Files.ReadWrite
+  - Contacts.Read
+  - People.Read
+  - User.Read
 6. Copy Application ID
 
 ### 2. Installation

--- a/src/m365_mcp/auth.py
+++ b/src/m365_mcp/auth.py
@@ -12,6 +12,11 @@ from typing import NamedTuple, Any
 # Store token cache in user's home directory for proper permissions and portability
 CACHE_FILE = pl.Path.home() / ".m365_mcp_token_cache.json"
 METADATA_FILE = pl.Path.home() / ".m365_mcp_account_metadata.json"
+
+# Reserved scopes such as offline_access are needed for refresh tokens but can be
+# rejected by some tenants (notably certain personal accounts). We attempt to
+# include them first and retry against the consumers authority so personal
+# accounts still receive refresh tokens for silent renewal.
 SCOPES = [
     "Calendars.Read",
     "Calendars.ReadBasic",
@@ -25,8 +30,10 @@ SCOPES = [
     "Mail.Send",
     "MailboxSettings.ReadWrite",
     "People.Read",
-    "User.Read"
+    "User.Read",
 ]
+RESERVED_SCOPES = ["offline_access"]
+DEVICE_FLOW_SCOPES = SCOPES + RESERVED_SCOPES
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +77,38 @@ def _write_cache(content: str) -> None:
     CACHE_FILE.write_text(content)
 
 
+def _build_app(
+    tenant_id: str, cache: msal.SerializableTokenCache | None = None
+) -> msal.PublicClientApplication:
+    """Construct an MSAL PublicClientApplication with the shared cache.
+
+    Args:
+        tenant_id: Tenant segment for the authority (for example, "common",
+            "consumers", or a specific directory ID).
+        cache: Reusable token cache. If omitted, the cache will be hydrated
+            from disk.
+
+    Returns:
+        Initialized PublicClientApplication.
+    """
+
+    client_id = os.getenv("M365_MCP_CLIENT_ID")
+    if not client_id:
+        raise ValueError("M365_MCP_CLIENT_ID environment variable is required")
+
+    cache_instance = cache or msal.SerializableTokenCache()
+    if cache is None:
+        cache_content = _read_cache()
+        if cache_content:
+            cache_instance.deserialize(cache_content)
+
+    authority = f"https://login.microsoftonline.com/{tenant_id}"
+
+    return msal.PublicClientApplication(
+        client_id, authority=authority, token_cache=cache_instance
+    )
+
+
 def _read_metadata() -> dict[str, dict]:
     """Read account metadata cache containing account types and other metadata.
 
@@ -91,6 +130,49 @@ def _write_metadata(metadata: dict[str, dict]) -> None:
     """
     METADATA_FILE.parent.mkdir(parents=True, exist_ok=True)
     METADATA_FILE.write_text(json.dumps(metadata, indent=2))
+
+
+def _initiate_device_flow(
+    app: msal.PublicClientApplication, tenant_id: str
+) -> tuple[msal.PublicClientApplication, dict[str, Any]]:
+    """Start a device code flow, retrying with a consumer authority if needed.
+
+    Certain personal Microsoft accounts can reject the ``offline_access`` scope
+    when using the ``common`` authority, which prevents refresh tokens from
+    being issued. To preserve silent renewal, retry with the ``consumers``
+    authority while reusing the same token cache.
+    """
+
+    def _start(current_app: msal.PublicClientApplication) -> dict[str, Any]:
+        flow = current_app.initiate_device_flow(scopes=DEVICE_FLOW_SCOPES)
+        if "user_code" in flow:
+            return flow
+
+        error_message = flow.get("error_description", flow.get("error", "Unknown error"))
+        raise Exception(error_message)
+
+    try:
+        return app, _start(app)
+    except Exception as exc:
+        message = str(exc).lower()
+        if "reserved" not in message and "offline_access" not in message:
+            raise
+
+        if tenant_id == "consumers":
+            raise
+
+        logger.warning(
+            "Device flow rejected reserved scope offline_access; "
+            "retrying with the consumers authority",
+        )
+
+        cache = (
+            app.token_cache
+            if isinstance(app.token_cache, msal.SerializableTokenCache)
+            else None
+        )
+        consumer_app = _build_app("consumers", cache=cache)
+        return consumer_app, _start(consumer_app)
 
 
 def _get_account_type(account_id: str, username: str) -> str:
@@ -138,28 +220,14 @@ def _get_account_type(account_id: str, username: str) -> str:
         return "unknown"
 
 
-def get_app() -> msal.PublicClientApplication:
-    client_id = os.getenv("M365_MCP_CLIENT_ID")
-    if not client_id:
-        raise ValueError("M365_MCP_CLIENT_ID environment variable is required")
-
+def get_app() -> tuple[msal.PublicClientApplication, str]:
     tenant_id = os.getenv("M365_MCP_TENANT_ID", "common")
-    authority = f"https://login.microsoftonline.com/{tenant_id}"
-
-    cache = msal.SerializableTokenCache()
-    cache_content = _read_cache()
-    if cache_content:
-        cache.deserialize(cache_content)
-
-    app = msal.PublicClientApplication(
-        client_id, authority=authority, token_cache=cache
-    )
-
-    return app
+    app = _build_app(tenant_id)
+    return app, tenant_id
 
 
 def get_token(account_id: str | None = None) -> str:
-    app = get_app()
+    app, tenant_id = get_app()
 
     accounts = app.get_accounts()
     account = None
@@ -182,11 +250,7 @@ def get_token(account_id: str | None = None) -> str:
         result = None
 
     if not result:
-        flow = app.initiate_device_flow(scopes=SCOPES)
-        if "user_code" not in flow:
-            raise Exception(
-                f"Failed to get device code: {flow.get('error_description', 'Unknown error')}"
-            )
+        app, flow = _initiate_device_flow(app, tenant_id)
         verification_uri = flow.get(
             "verification_uri",
             flow.get("verification_url", "https://microsoft.com/devicelogin"),
@@ -224,7 +288,7 @@ def list_accounts() -> list[Account]:
         List of Account objects with username, account_id, and account_type.
         Account type will be "unknown" if not yet detected.
     """
-    app = get_app()
+    app, _ = get_app()
     metadata = _read_metadata()
 
     accounts = []
@@ -250,19 +314,16 @@ def authenticate_new_account() -> Account | None:
         Account object with username, account_id, and detected account_type,
         or None if authentication failed.
     """
-    app = get_app()
+    app, tenant_id = get_app()
 
-    flow = app.initiate_device_flow(scopes=SCOPES)
-    if "user_code" not in flow:
-        raise Exception(
-            f"Failed to get device code: {flow.get('error_description', 'Unknown error')}"
-        )
+    app, flow = _initiate_device_flow(app, tenant_id)
 
     print("\nTo authenticate:", file=sys.stderr)
-    print(
-        f"1. Visit: {flow.get('verification_uri', flow.get('verification_url', 'https://microsoft.com/devicelogin'))}",
-        file=sys.stderr,
+    verification_url = flow.get(
+        "verification_uri",
+        flow.get("verification_url", "https://microsoft.com/devicelogin"),
     )
+    print(f"1. Visit: {verification_url}", file=sys.stderr)
     print(f"2. Enter code: {flow['user_code']}", file=sys.stderr)
     print("3. Sign in with your Microsoft account", file=sys.stderr)
     print("\nWaiting for authentication...", file=sys.stderr)


### PR DESCRIPTION
## Summary
- reuse a shared token cache when building MSAL apps and expose tenant-aware helpers
- retry device code flow against the consumers authority so personal accounts still receive refresh tokens
- document the personal-account retry behavior in the setup instructions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69446df7cc00832b82ed39d4df26b54a)